### PR TITLE
Editorial improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,8 @@ al pattern `[A-ZA-Z0-9 _-.]{, 64}`.
 Gli spazi NON DEVONO essere utilizzati nei file o nei nomi delle directory.
 Le directory DEVONO essere in minuscolo.
 
-Il nome di ciascun file DEVE corrispondere al nome della relativa risorsa 
-nell'URI utilizzato per referenziarla. 
+Il nome di ciascun file DEVE corrispondere al nome della relativa risorsa
+nell'URI utilizzato per referenziarla.
 I nomi dei file di una directory DEVONO corrispondere al nome della directory
 che li contiene, a meno dell'estensione degli stessi.
 

--- a/REDIRECT.en.md
+++ b/REDIRECT.en.md
@@ -35,7 +35,7 @@ In the local repository created starting from the fork, it will be necessary to 
 
 Below is an example of a folder tree under `/italia`:
 
-<pre>
+```
 italia
 |--folder-name
 |   |--controlled-vocabulary
@@ -45,12 +45,12 @@ italia
 |   |--onto
 |   |   |-.htaccess
 |   |README.md
-</pre>
+```
 
 This will define the following URIs:
--	`w3id.org/italia/<folder-name>/controlled-vocabulary`
--	`w3id.org/italia/<folder-name>/data`
--	`w3id.org/italia/<folder-name>/onto`
+-	`https://w3id.org/italia/<folder-name>/controlled-vocabulary`
+-	`https://w3id.org/italia/<folder-name>/data`
+-	`https://w3id.org/italia/<folder-name>/onto`
 
 The `<folder-name>` is very important as it MUST be placed in specific parameters described later in this document, and will always be used to refer to the Contributor's set of semantic resources as part of the redirect file configuration.
 
@@ -73,46 +73,54 @@ It contains code written based on Apache Directives, and allows you to manage HT
 
 Below is a description of the example directives, to which the references of the landing URLs MUST be modified, in addition to any modification/integration of the rules in order to better adapt to the Contributor's git:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 This line sets the Access-Control-Allow-Origin header to *, allowing any domain to access resources on the server via Ajax requests or from other different domains.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 This line enables the FollowSymLinks option, which allows the server to follow symbolic links (symlinks) within the file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 This line activates Apache's URL rewriting engine (mod_rewrite), which allows you to manipulate the URLs of HTTP requests.
 
-<pre>
+```
 SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
 SetEnvIf Accept ^.*application/json.* SYNTAX=json
 SetEnvIf Accept ^.*application/csv.* SYNTAX=csv
 SetEnvIf Accept ^.*text/csv.* SYNTAX=csv
 SetEnvIf Accept ^.*text/html.* SYNTAX=html
-</pre>
+```
+
 These lines set an environment variable called SYNTAX based on the Accept header of the HTTP request. This is used to determine the type of syntax required in the response. These lines MUST be modified depending on the file formats present in your github folders.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL="url-git"
-</pre>
+```
+
 Set the ROOT_URL environment variable with a fixed URL. The URL entered MUST be that of your repository pointing to the controlled vocabularies folder (in the format `https://raw.githubusercontent.com/...`)
 
-<pre>
+
+```
 RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
 RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
-</pre>
+```
+
 Defines the URL rewriting rule if the requested file type is ttl, json or csv ( types MUST be configured based on the file types present in the source repository).
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/controlled-vocabulary/$1 [R=303,L]
 RewriteRule ^(.+)/(.+)/(.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/controlled-vocabulary/$1/$2/$3 [R=303,L]
-</pre>
+```
+
 The previous conditions apply only when SYNTAX is html, or in all other cases not managed by the previous conditions. They rewrite URLs differently, redirecting to external URLs based on specific patterns. They MUST be configured based on the name of the thematic folder which refers to the particular set of semantic resources in the w3id's git.
 
 ### onto
@@ -123,49 +131,56 @@ It contains code written based on Apache Directives, and allows you to manage HT
 
 Below is a description of the example directives, to which the landing URL references MUST be modified, in addition to any modification/integration of the rules in order to better adapt to the Contributor's git:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 This line sets the Access-Control-Allow-Origin header to *, allowing any domain to access resources on the server via Ajax requests or from other different domains.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 This line enables the FollowSymLinks option, which allows the server to follow symbolic links (symlinks) within the file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 This line activates Apache's URL rewriting engine (mod_rewrite), which allows you to manipulate the URLs of HTTP requests.
 
-<pre>
+```
 SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
 SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=owl
 SetEnvIf Accept ^.*application/n-triples.* SYNTAX=n3
 SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
 SetEnvIf Accept ^.*text/html.* SYNTAX=html
-</pre>
+```
+
 These lines set an environment variable called SYNTAX based on the Accept header of the HTTP request. This is used to determine the type of syntax required in the response. These lines MUST be modified according to the file formats present in your folders in the semantic resources repository.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL="url-git"
-</pre>
+```
+
 Set the ROOT_URL environment variable with a fixed URL. The URL entered MUST be that of your repository pointing to the ontologies folder (in the format `https://raw.githubusercontent.com/...`)
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|owl|n3)$
 RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
-</pre>
+```
+
 Defines the URL rewriting rule if the requested file type is rdf, ttl, own or n3 (file types MUST be configured based on the file types present in the source repository).
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)(/.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/onto/$1$2 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)/$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/{{nome-cartella}}/onto/$1 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/{{nome-cartella}}/onto/$1 [R=303,L]
-</pre>
+```
+
 The above conditions apply only when SYNTAX is html. They rewrite URLs differently, redirecting to external URLs based on specific patterns. They MUST be configured based on the name of the thematic folder which refers to the particular set of semantic resources in the w3id's git.
 
 ### data
@@ -176,35 +191,41 @@ It contains code written based on the Apache Directives, and allows you to confi
 
 Below is a description of the example directives, to which the landing URL references MUST be modified, in addition to any modification/integration of the rules in order to better adapt to the Contributor's git:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 This line sets the Access-Control-Allow-Origin header to *, allowing any domain to access resources on the server via Ajax requests or from other different domains.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 Questa riga abilita l'opzione FollowSymLinks, che permette al server di seguire i collegamenti simbolici (symlink) all'interno del file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 This line enables the FollowSymLinks option, which allows the server to follow symbolic links (symlinks) within the file system.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL=https://schema.gov.it/lodview/{{nome-cartella}}/data/
-</pre>
+```
+
 This line sets an environment variable called ROOT_URL, which MUST be changed based on the subject folder name
 which refers to your semantic resource repository on w3id.
 
-<pre>
+```
 RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
-</pre>
+```
+
 This line is a URL rewrite rule. Every request that comes to the server will be rewritten to include the value of ROOT_URL before the requested URI. The [R=303,L] flag indicates that the HTTP response will be a temporary redirect (status code 303) and that this is the last rule to be applied.
 
-<pre>
+```
 RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]
-</pre>
+```
+
 This is a similar rewrite rule to the previous one, but only applies to requests that end with a slash. Again, the response will be a temporary redirect with status code 303.
 
 ### README.md

--- a/REDIRECT.en.md
+++ b/REDIRECT.en.md
@@ -1,10 +1,10 @@
 # URI Redirection guide
 
 This document provides guidance for creating and publishing
-`htaccess` files that allow redirection of semantic resources 
-URIs using the w3id. This guide is based on the 
+`htaccess` files that allow redirection of semantic resources
+URIs using the w3id. This guide is based on the
 [w3id.org permanent identifiers guide](https://w3id.org/), and it is
-specialized on the redirect configuration of semantic assets' URIs 
+specialized on the redirect configuration of semantic assets' URIs
 under the Italia domain.
 
 ## Requirements Notation
@@ -18,7 +18,9 @@ and only when, they appear in all capitals, as shown here.
 
 [w3id.org](https://w3id.org/) is a solution from the W3C Permanent Identifier Community Group that allows the addition or modification of permanent identifiers from which to redirect to specific URLs; the process is based on adding one or more folders in the [w3id git repository](https://github.com/perma-id/w3id.org), which MUST contain the `.htaccess` files and `README.md`, possibly organized into subfolders.
 
-In the case of the Catalogue, it is necessary to refer to the [Italy folder of the w3id GIT](https://github.com/perma-id/w3id.org/tree/master/italia), in which the subfolders MUST be added, each for a particular thematic area, which will contain the redirection files, possibly organized in further subfolders, and the `README.md` file. The addition of the `/Italy` subfolders will be subject to approval by the Italy Committee; subsequently, they will be managed independently and with direct interfacing between w3id.org and the contacts indicated in the `README.md`. The folder and its subfolders, `.htaccess` files, and `README.md` files MUST be created on the [w3id git repository](https://github.com/perma-id/w3id.org) by the Contributor.
+In the case of the Catalogue, it is necessary to refer to the [Italy folder of the w3id GIT](https://github.com/perma-id/w3id.org/tree/master/italia), in which the subfolders MUST be added, each for a particular thematic area, which will contain the redirection files, possibly organized in further subfolders, and the `README.md` file.
+The addition of the `italia/` subfolders will be subject to approval by the Italy Committee; subsequently, they will be managed independently and with direct interfacing between w3id.org and the contacts indicated in the `README.md`.
+The folder and its subfolders, `.htaccess` files, and `README.md` files MUST be created on the [w3id git repository](https://github.com/perma-id/w3id.org) by the Contributor.
 
 ## Publishing htaccess on w3id
 
@@ -27,7 +29,7 @@ In the case of the Catalogue, it is necessary to refer to the [Italy folder of t
 The first step for registering the redirects is the local fork of the
 [w3id GIT Italy folder](https://github.com/perma-id/w3id.org/tree/master/italia). The
 permanent identifiers (URI) will be defined based on the path in which the various `htaccess` files will be inserted.
-In this case, the path to the "root" folder for folder-name must be `italia/<folder-name>/`, therefore the namespace of the URIs defined in it will be `w3id.org/italia/<folder-name>/`.
+In this case, the path to the "root" folder for folder-name must be `italia/<folder-name>/`, therefore the namespace of the URIs defined in it will be `https://w3id.org/italia/<folder-name>/`.
 
 ### 2. adding the folder
 

--- a/REDIRECT.md
+++ b/REDIRECT.md
@@ -42,7 +42,7 @@ Nel repository in locale creato a partire dalla fork occorrerà creare la cartel
 
 Di seguito è fornito un esempio di alberatura della cartella sotto `/italia`:
 
-<pre>
+```
 italia
 |--nome-cartella
 |   |--controlled-vocabulary
@@ -52,7 +52,7 @@ italia
 |   |--onto
 |   |   |-.htaccess
 |   |README.md
-</pre>
+```
 
 In tal modo, verranno definiti i seguenti URI:
 -	`w3id.org/italia/<nome-cartella>/controlled-vocabulary`
@@ -81,46 +81,53 @@ Esso contiene codice scritto sulla base delle Direttive Apache, e permette di ge
  
 Di seguito viene data una descrizione delle direttive di esempio, alle quali DEVONO essere modificati i riferimenti degli URL di atterraggio, oltre all’eventuale modifica/integrazione delle regole al fine di meglio adattarsi al git del Contributore:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 Questa riga imposta l'header Access-Control-Allow-Origin su *, consentendo a qualsiasi dominio di accedere alle risorse sul server tramite richieste Ajax o da altri domini diversi.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 Questa riga abilita l'opzione FollowSymLinks, che permette al server di seguire i collegamenti simbolici (symlink) all'interno del file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 Questa riga attiva il motore di riscrittura delle URL di Apache (mod_rewrite), che permette di manipolare le URL delle richieste HTTP.
 
-<pre>
+```
 SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
 SetEnvIf Accept ^.*application/json.* SYNTAX=json
 SetEnvIf Accept ^.*application/csv.* SYNTAX=csv
 SetEnvIf Accept ^.*text/csv.* SYNTAX=csv
 SetEnvIf Accept ^.*text/html.* SYNTAX=html
-</pre>
+```
+
 Queste righe impostano una variabile di ambiente chiamata SYNTAX in base all'header Accept della richiesta HTTP. Questo viene utilizzato per determinare il tipo di sintassi richiesto nella risposta. Queste righe DEVONO essere modificate a seconda dei formati dei file presenti nelle proprie cartelle github.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL="url-git"
-</pre>
+```
+
 Imposta la variabile di ambiente ROOT_URL con un URL fisso. L’URL inserito DEVE essere quello del proprio Github che punta alla cartella dei vocabolari controllati (in formato `https://raw.githubusercontent.com/...`)
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^(ttl|json|csv)$
 RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
-</pre>
+```
+
 Definisce la regola di riscrittura dell'URL nel caso in cui il tipo file richiesto sia ttl, json o csv (questi ultimi DEVONO essere configurati sulla base dei tipi file presenti nel repository sorgente).
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/controlled-vocabulary/$1 [R=303,L]
 RewriteRule ^(.+)/(.+)/(.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/controlled-vocabulary/$1/$2/$3 [R=303,L]
-</pre>
+```
+
 Le precedenti condizioni si applicano solo quando SYNTAX è html, oppure in tutti gli altri casi non gestiti dalle precedenti condizioni. Riscrivono le URL in modo diverso, reindirizzando a URL esterni basati su modelli specifici. DEVONO essere configurati sulla base del nome della cartella tematica con la quale ci si riferisce al particolare insieme di risorse semantiche nel git del w3id.
 
 ### onto
@@ -131,49 +138,56 @@ Esso contiene codice scritto sulla base delle Direttive Apache, e permette di ge
 
 Di seguito viene data una descrizione delle direttive di esempio, alle quali DEVONO essere modificati i riferimenti degli URL di atterraggio, oltre all’eventuale modifica/integrazione delle regole al fine di meglio adattarsi al git del Contributore:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 Questa riga imposta l'header Access-Control-Allow-Origin su *, consentendo a qualsiasi dominio di accedere alle risorse sul server tramite richieste Ajax o da altri domini diversi.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 Questa riga abilita l'opzione FollowSymLinks, che permette al server di seguire i collegamenti simbolici (symlink) all'interno del file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 Questa riga attiva il motore di riscrittura delle URL di Apache (mod_rewrite), che permette di manipolare le URL delle richieste HTTP.
 
-<pre>
+```
 SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=rdf
 SetEnvIf Accept ^.*application/rdf\+xml.* SYNTAX=owl
 SetEnvIf Accept ^.*application/n-triples.* SYNTAX=n3
 SetEnvIf Accept ^.*text/turtle.* SYNTAX=ttl
 SetEnvIf Accept ^.*text/html.* SYNTAX=html
-</pre>
+```
+
 Queste righe impostano una variabile di ambiente chiamata SYNTAX in base all'header Accept della richiesta HTTP. Questo viene utilizzato per determinare il tipo di sintassi richiesto nella risposta. Queste righe DEVONO essere modificate a seconda dei formati dei file presenti nelle proprie cartelle nel repository delle risorse semantiche.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL="url-git"
-</pre>
+```
+
 Imposta la variabile di ambiente ROOT_URL con un URL fisso. L’URL inserito DEVE essere quello del proprio repository che punta alla cartella delle ontologie (in formato `https://raw.githubusercontent.com/...`)
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^(rdf|ttl|owl|n3)$
 RewriteRule ^([a-zA-Z-_0-9]+)(/?)$ %{ENV:ROOT_URL}$1/latest/$1.%{ENV:SYNTAX} [R=303,L]
-</pre>
+```
+
 Definisce la regola di riscrittura dell'URL nel caso in cui il tipo file richiesto sia rdf, ttl, own o n3 (questi ultimi DEVONO essere configurati sulla base dei tipi file presenti nel repository sorgente).
 
-<pre>
+```
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)(/.+)$ https://schema.gov.it/lodview/{{nome-cartella}}/onto/$1$2 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)/$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/{{nome-cartella}}/onto/$1 [R=303,L]
 RewriteCond %{ENV:SYNTAX} ^html$
 RewriteRule ^(.+)$ https://schema.gov.it/lode/extract?url=https://w3id.org/italia/{{nome-cartella}}/onto/$1 [R=303,L]
-</pre>
+```
+
 Le precedenti condizioni si applicano solo quando SYNTAX è html. Riscrivono le URL in modo diverso, reindirizzando a URL esterni basati su modelli specifici. DEVONO essere configurati sulla base del nome della cartella tematica con la quale ci si riferisce al particolare insieme di risorse semantiche nel git del w3id.
 
 ### data
@@ -184,35 +198,41 @@ Esso contiene codice scritto sulla base delle Direttive Apache, e permette di co
 
 Di seguito viene data una descrizione delle direttive di esempio, alle quali DEVONO essere modificati i riferimenti degli URL di atterraggio, oltre all’eventuale modifica/integrazione delle regole al fine di meglio adattarsi al git del Contributore:
 
-<pre>
+```
 Header set Access-Control-Allow-Origin *
-</pre>
+```
+
 Questa riga imposta l'header Access-Control-Allow-Origin su *, consentendo a qualsiasi dominio di accedere alle risorse sul server tramite richieste Ajax o da altri domini diversi.
 
-<pre>
+```
 Options +FollowSymLinks
-</pre>
+```
+
 Questa riga abilita l'opzione FollowSymLinks, che permette al server di seguire i collegamenti simbolici (symlink) all'interno del file system.
 
-<pre>
+```
 RewriteEngine on
-</pre>
+```
+
 Questa riga attiva il motore di riscrittura delle URL di Apache (mod_rewrite), che permette di manipolare le URL delle richieste HTTP.
 
-<pre>
+```
 SetEnvIf Request_URI ^.*$ ROOT_URL=https://schema.gov.it/lodview/{{nome-cartella}}/data/
-</pre>
+```
+
 Questa riga imposta una variabile di ambiente chiamata ROOT_URL, che DEVE essere modificata sulla base del nome della cartella tematica
 con la quale ci si riferisce al proprio repository di risorse semantiche su w3id.
 
-<pre>
+```
 RewriteRule ^(.*)$ %{ENV:ROOT_URL}$1 [R=303,L]
-</pre>
+```
+
 Questa riga è una regola di riscrittura delle URL. Ogni richiesta che arriva al server verrà riscritta in modo da includere il valore di ROOT_URL prima dell'URI richiesto. Il flag [R=303,L] indica che la risposta HTTP sarà un redirect temporaneo (codice di stato 303) e che questa è l'ultima regola da applicare.
 
-<pre>
+```
 RewriteRule ^(.*)/$ %{ENV:ROOT_URL}$1 [R=303,L]
-</pre>
+```
+
 Questa è una regola di riscrittura simile alla precedente, ma si applica solo alle richieste che terminano con una barra. Anche in questo caso, la risposta sarà un redirect temporaneo con codice di stato 303.
 
 ### README.md

--- a/REDIRECT.md
+++ b/REDIRECT.md
@@ -2,9 +2,9 @@
 
 Questo documento fornisce una guida per la creazione e la pubblicazione
 dei file `htaccess` che permettono il redirect delle URI delle risorse
-semantiche utilizzando il w3id. La presente guida è basata sulla 
+semantiche utilizzando il w3id. La presente guida è basata sulla
 [guida ai permanent identifiers del w3id.org](https://w3id.org/), ed è
-specializzata sulla configurazione del redirect delle URI di risorse 
+specializzata sulla configurazione del redirect delle URI di risorse
 semantiche sotto il dominio "Italia".
 
 ## Terminologia
@@ -24,16 +24,17 @@ questo documento utilizza le parole chiave "DEVE", "DEVONO", "NON DEVE", "NON DE
 
 [w3id.org](https://w3id.org/) è una soluzione del W3C Permanent Identifier Community Group che permette l’aggiunta o modifica di identificativi permanenti a partire dai quali reindirizzare verso URL specifici; il processo si basa  sull’aggiunta di una o più cartelle nel [repository git del w3id](https://github.com/perma-id/w3id.org), le quali DEVONO contenere i file `.htaccess` e file `README.md`, eventualmente organizzati in sottocartelle.
 
-Nel caso del Catalogo, occorre fare riferimento alla [cartella Italia del GIT del w3id](https://github.com/perma-id/w3id.org/tree/master/italia), nella quale DEVONO essere aggiunte le sottocartelle, ciascuna per una particolare area tematica, che conterranno i file di reindirizzamento, eventualmente organizzati in ulteriori sottocartelle, ed il file `README.md`. L’aggiunta delle sottocartelle di `/Italia` sarà sottoposta ad approvazione del Comitato Italia; successivamente, le stesse saranno gestite autonomamente e con interfacciamento diretto verso w3id.org dai referenti indicati nei file `README.md`. La cartella e le relative sottocartelle, i  file `.htaccess` e i file `README.md` DEVONO essere creati sul [repository git del w3id](https://github.com/perma-id/w3id.org) dall'Organizzazione contributrice.
+Nel caso del Catalogo, occorre fare riferimento alla [cartella `italia` del git del w3id](https://github.com/perma-id/w3id.org/tree/master/italia), nella quale DEVONO essere aggiunte le sottocartelle, ciascuna per una particolare area tematica, che conterranno i file di reindirizzamento, eventualmente organizzati in ulteriori sottocartelle, ed il file `README.md`.
+L’aggiunta delle sottocartelle di `italia/` sarà sottoposta ad approvazione del Comitato Italia; successivamente, le stesse saranno gestite autonomamente e con interfacciamento diretto verso w3id.org dai referenti indicati nei file `README.md`. La cartella e le relative sottocartelle, i  file `.htaccess` e i file `README.md` DEVONO essere creati sul [repository git del w3id](https://github.com/perma-id/w3id.org) dall'Organizzazione contributrice.
 
 ## Processo di pubblicazione degli htaccess sul w3id
 
-### 1. fork del repository GIT del w3id.org
+### 1. fork del repository git del w3id.org
 
 Il primo passo per la registrazione dei vari redirect è il fork in locale della
-[cartella Italia del GIT del w3id](https://github.com/perma-id/w3id.org/tree/master/italia). Gli 
-identificativi permanenti (URI) verranno definiti sulla base del percorso nel quale saranno inseriti i vari file `htaccess`. Nel caso del Catalogo, il percorso della cartella “root” per nome-cartella dovrà essere 
-`italia/<nome-cartella>/`, dunque il namespace degli URI definiti nella stessa sarà 
+[cartella `italia` del git del w3id](https://github.com/perma-id/w3id.org/tree/master/italia). Gli
+identificativi permanenti (URI) verranno definiti sulla base del percorso nel quale saranno inseriti i vari file `htaccess`. Nel caso del Catalogo, il percorso della cartella `root` per nome-cartella dovrà essere
+`italia/<nome-cartella>/`, dunque il namespace degli URI definiti nella stessa sarà
 `w3id.org/italia/<nome-cartella>/`.
 
 ### 2. aggiunta della cartella
@@ -55,18 +56,19 @@ italia
 ```
 
 In tal modo, verranno definiti i seguenti URI:
--	`w3id.org/italia/<nome-cartella>/controlled-vocabulary`
--	`w3id.org/italia/<nome-cartella>/data`
--	`w3id.org/italia/<nome-cartella>/onto`
 
-Il `<nome-cartella>` è molto importante dato che DEVE essere inserito in specifici parametri descritti di seguito nel presente documento, 
+- `https://w3id.org/italia/<nome-cartella>/controlled-vocabulary`
+- `https://w3id.org/italia/<nome-cartella>/data`
+- `https://w3id.org/italia/<nome-cartella>/onto`
+
+Il `<nome-cartella>` è molto importante dato che DEVE essere inserito in specifici parametri descritti di seguito nel presente documento,
 e sarà sempre utilizzato per riferirsi all'insieme delle risorse semantiche del Contributore nell'ambito della configurazione dei file di redirect.
 
 Le regole di redirect associate a ciascun uri DEVONO essere definite nei relativi file `.htaccess` descritti di seguito. Il file `README.md` DEVE contenere i nominativi dei referenti unitamente ai loro riferimenti e-mail e di github. Questi riferimenti DEVONO curare la gestione della cartella e dei relativi file a seguito dell’approvazione di “Italia”. Si DOVREBBE prendere come esempio il file `README.md` sotto la cartella `/italia`.
 
 ### 3. creazione della pull request
 
-Una volta modificato il repository GIT in locale, si DEVE creare una pull request, la quale sarà analizzata ed eventualmente validata da "Italia"; nella pull request DEVONO essere indicati come reviewer i contatti presenti nel [file README.md sotto `/italia`](https://github.com/perma-id/w3id.org/blob/master/italia/readme.md).
+Una volta modificato il repository git in locale, si DEVE creare una pull request, la quale sarà analizzata ed eventualmente validata da "Italia"; nella pull request DEVONO essere indicati come reviewer i contatti presenti nel [file README.md sotto `/italia`](https://github.com/perma-id/w3id.org/blob/master/italia/readme.md).
 Il merge sul branch master verrà effettuato direttamente da w3id.org e determinerà la pubblicazione definitiva dei nuovi URI e relative regole di redirect.
 
 ## Contenuto dei file .htaccess e del README.md
@@ -75,10 +77,10 @@ Di seguito è data una descrizione di file `.htaccess` per ciascuna tipologia di
 
 ### controlled-vocabulary
 
-Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/controlled-vocabulary` DOVREBBE essere creato a prendendo come esempio [quello contenuto nella cartella del GIT `italia/controlled-vocabulary`](https://github.com/perma-id/w3id.org/blob/master/italia/controlled-vocabulary/.htaccess).
+Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/controlled-vocabulary` DOVREBBE essere creato a prendendo come esempio [quello contenuto nella cartella del git `italia/controlled-vocabulary`](https://github.com/perma-id/w3id.org/blob/master/italia/controlled-vocabulary/.htaccess).
 
 Esso contiene codice scritto sulla base delle Direttive Apache, e permette di gestire le richieste HTTP in base al valore dell'header Accept e di SYNTAX. A seconda del valore, le URL vengono riscritte in modo diverso o reindirizzate a URL esterni. La specifica azione di riscrittura o reindirizzamento dipende dalla combinazione di Accept e SYNTAX.
- 
+
 Di seguito viene data una descrizione delle direttive di esempio, alle quali DEVONO essere modificati i riferimenti degli URL di atterraggio, oltre all’eventuale modifica/integrazione delle regole al fine di meglio adattarsi al git del Contributore:
 
 ```
@@ -132,7 +134,7 @@ Le precedenti condizioni si applicano solo quando SYNTAX è html, oppure in tutt
 
 ### onto
 
-Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/onto` DOVREBBE essere creato a partire da [quello contenuto nella cartella del GIT `italia/onto`](https://github.com/perma-id/w3id.org/blob/master/italia/onto/.htaccess).
+Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/onto` DOVREBBE essere creato a partire da [quello contenuto nella cartella del git `italia/onto`](https://github.com/perma-id/w3id.org/blob/master/italia/onto/.htaccess).
 
 Esso contiene codice scritto sulla base delle Direttive Apache, e permette di gestire le richieste HTTP in base al valore dell'header Accept e di SYNTAX. A seconda del valore, le URL vengono riscritte in modo diverso o reindirizzate a URL esterni. La specifica azione di riscrittura o reindirizzamento dipende dalla combinazione di Accept e SYNTAX.
 
@@ -192,9 +194,9 @@ Le precedenti condizioni si applicano solo quando SYNTAX è html. Riscrivono le 
 
 ### data
 
-Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/data` DOVREBBE essere creato a partire da [quello contenuto nella cartella del GIT `italia/data`](https://github.com/perma-id/w3id.org/blob/master/italia/data/.htaccess).
+Il file `.htaccess` da inserire nella sottocartella `italia/nome-cartella/data` DOVREBBE essere creato a partire da [quello contenuto nella cartella del git `italia/data`](https://github.com/perma-id/w3id.org/blob/master/italia/data/.htaccess).
 
-Esso contiene codice scritto sulla base delle Direttive Apache, e permette di configurare il server Apache per consentire l'accesso da qualsiasi dominio alle risorse del server, impostare una variabile di ambiente ROOT_URL con un valore fisso, e quindi riscrivere tutte le richieste in modo che includano ROOT_URL prima dell'URI richiesto. 
+Esso contiene codice scritto sulla base delle Direttive Apache, e permette di configurare il server Apache per consentire l'accesso da qualsiasi dominio alle risorse del server, impostare una variabile di ambiente ROOT_URL con un valore fisso, e quindi riscrivere tutte le richieste in modo che includano ROOT_URL prima dell'URI richiesto.
 
 Di seguito viene data una descrizione delle direttive di esempio, alle quali DEVONO essere modificati i riferimenti degli URL di atterraggio, oltre all’eventuale modifica/integrazione delle regole al fine di meglio adattarsi al git del Contributore:
 


### PR DESCRIPTION
## This PR

- editorial improvements (typographic)
- pre-commit cleanup
- fix `Italia` vs `italia`


## Notes

- since the REDIRECT* files are not repository-specific, I suggest to move them to the schema.gov.it manual. This allows to have an always-updated reference.
- if this information is in the repository, next year we have no guarantees that the information is aligned/correct.

WDYT? 